### PR TITLE
Add FLAC support

### DIFF
--- a/deezer_downloader/deezer.py
+++ b/deezer_downloader/deezer.py
@@ -342,6 +342,7 @@ def download_song(song, output_file):
                    1
         urlkey = genurlkey(song["SNG_ID"], song["MD5_ORIGIN"], song["MEDIA_VERSION"], song_quality)
         url = "https://e-cdns-proxy-%s.dzcdn.net/mobile/1/%s" % (song["MD5_ORIGIN"][0], urlkey.decode())
+        extension = 'mp3'
     key = calcbfkey(song["SNG_ID"])
     if not url:
         print("ERROR: Can not download this song. Failed to get url.")

--- a/deezer_downloader/web/music_backend.py
+++ b/deezer_downloader/web/music_backend.py
@@ -105,9 +105,11 @@ def download_song_and_get_absolute_filename(search_type, song, playlist_name=Non
 
     if os.path.exists(absolute_filename):
         print("Skipping song '{}'. Already exists.".format(absolute_filename))
+    if os.path.exists(absolute_filename.replace('.mp3', '.flac')):
+        print("Skipping song '{}'. Already exists.".format(absolute_filename.replace('.mp3', '.flac')))    
     else:
         print("Downloading '{}'".format(song_filename))
-        download_song(song, absolute_filename)
+        absolute_filename = download_song(song, absolute_filename)
     return absolute_filename
 
 


### PR DESCRIPTION
I've used this to download a couple of playlists and it seems to work so far (using the free trial).
It'd be good if someone could test that it doesn't break operation with free accounts since i don't currently have one.
I've yet to observe any songs with AAC as an option so the change to the "exists already" check doesn't handle that yet.
I'm not sure how robust the error handling is if the server returns results in an unexpected format.

The web client gets media urls with a seperate API call using TRACK_TOKEN from the song data, the encryption on FLACs seems unchanged.
Some songs have a "Fallback" to a different ID and do not allow downloads using the original id, this is currently handled after failing on the original file but it might be worth not trying the original if a fallback is supplied.
