### PR TITLE
Bug fix: inverted `startswith` condition in config validation

### DIFF
--- a/deezer_downloader/configuration.py
+++ b/deezer_downloader/configuration.py
@@ -19,7 +19,7 @@ def load_config(config_abs):
     assert list(config.keys()) == ['DEFAULT', 'mpd', 'download_dirs', 'debug', 'http', 'proxy', 'threadpool', 'deezer', 'youtubedl'], f"Validating config file failed. Check {config_abs}"
 
     if config['mpd'].getboolean('use_mpd'):
-        if not config['mpd']['music_dir_root'].startswith(config['download_dirs']['base']):
+        if not config['download_dirs']['base'].startswith(config['mpd']['music_dir_root']):
             print("ERROR: base download dir must be a subdirectory of the mpd music_dir_root")
             sys.exit(1)
 


### PR DESCRIPTION
### Problem

When `use_mpd = True`, the config validation incorrectly rejects a valid configuration.

With the following config:
```ini
[mpd]
music_dir_root = /home/user/Music

[download_dirs]
base = /home/user/Music/deezer-downloader
```

Running the app fails immediately:
```
ERROR: base download dir must be a subdirectory of the mpd music_dir_root
```

### Root cause

In `configuration.py`, the condition is inverted:

```python
# Current (wrong)
if not config['mpd']['music_dir_root'].startswith(config['download_dirs']['base']):
```

This tests whether `music_dir_root` starts with `base`, which is the opposite of what the error message describes.

### Fix

```python
# Fixed
if not config['download_dirs']['base'].startswith(config['mpd']['music_dir_root']):
```

This correctly checks that `base` is a subdirectory of `music_dir_root`, as stated in the error message.