### PR TITLE
Update audio save method to use v2_version=3

### DIFF
--- a/deezer_downloader/deezer.py
+++ b/deezer_downloader/deezer.py
@@ -296,7 +296,7 @@ def write_song_metadata(output_file: str, song: dict, is_flac: bool) -> None:
 
     set_metadata(audio, "picture", downloadpicture(song["ALB_PICTURE"]))
     set_metadata(audio, "albumartist", song.get('ALB_ART_NAME', song.get('ART_NAME', None)))
-    audio.save()
+    audio.save(v2_version=3)
 
 
 def get_song_infos_from_deezer_website(search_type, id):


### PR DESCRIPTION
Use ID3v2.3 for MP3 metadata to improve artwork compatibility across Windows Explorer, VLC, and other media players. Mutagen defaults to ID3v2.4, which causes embedded album art to not display correctly in some software despite the APIC frame being present.